### PR TITLE
fix: sanitize AI Agent query params and correct node subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ SearchApi is a fast, reliable SERP and data extraction API that focuses on perfo
 - [Operations](#operations)
 - [Credentials](#credentials)
 - [Usage](#usage)
+- [Use with n8n AI Agents](#use-with-n8n-ai-agents)
 - [Resources](#resources)
 - [Version history](#version-history)
 - [Troubleshooting](#troubleshooting)
@@ -16,7 +17,15 @@ SearchApi is a fast, reliable SERP and data extraction API that focuses on perfo
 
 ## Installation
 
-Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes/installation/) in the n8n community nodes documentation.
+**Recommended:** install from inside n8n.
+
+1. Open **Settings → Community nodes** (or search for nodes in the editor).
+2. Search for **SearchApi**.
+3. Click **Install**.
+
+You can also follow the [installation guide](https://docs.n8n.io/integrations/community-nodes/installation/) in the n8n community nodes documentation.
+
+Package name: `@searchapi/n8n-nodes-searchapi`
 
 ## Operations
 
@@ -49,6 +58,33 @@ The node supports one main operation: `Search`. You can use it to search from al
 
 ![Usage](images/steps.png)
 
+## Use with n8n AI Agents
+
+The SearchApi node is marked `usableAsTool: true`, so n8n can expose it as a tool for AI Agents.
+
+### Quick pattern
+
+1. Add an **AI Agent** node to your workflow.
+2. Connect **SearchApi** as a tool (not only on the main path).
+3. Select engine `google` (or another supported engine).
+4. Leave the query field dynamic so the agent can fill it at runtime.
+5. Ask the agent a question that needs fresh web data.
+
+Example prompt for the agent:
+
+> Search the live web for recent information about {{topic}} and summarize the top results with source titles and links.
+
+### Example workflow
+
+Import the sample workflow in [`examples/ai-agent-google-search.workflow.json`](examples/ai-agent-google-search.workflow.json):
+
+1. In n8n: **Workflows → Import from File**.
+2. Select `examples/ai-agent-google-search.workflow.json`.
+3. Attach your **SearchApi** credential and an LLM credential.
+4. Run the workflow with a chat/input message.
+
+This gives agents grounded, up-to-date search results instead of relying only on model training data.
+
 ## Resources
 
 - **SearchApi.io documentation** – [https://www.searchapi.io/](https://www.searchapi.io/docs/google)
@@ -57,10 +93,12 @@ The node supports one main operation: `Search`. You can use it to search from al
 
 ## Troubleshooting
 
-| Error message                | Likely cause                 | Fix                                                                         |
-| ---------------------------- | ---------------------------- | --------------------------------------------------------------------------- |
-| **401 Unauthorized**         | Invalid or missing API key   | Double‑check the credentials.                                           |
-| **429 Too Many Requests**    | Rate limit exceeded          | Slow down the workflow or [upgrade plan](https://www.searchapi.io/pricing). |
+| Error message | Likely cause | Fix |
+| --- | --- | --- |
+| **401 Unauthorized** | Invalid or missing API key | Double-check the credentials. |
+| **429 Too Many Requests** | Rate limit exceeded | Slow down the workflow or [upgrade plan](https://www.searchapi.io/pricing). |
+| **Error loading package / tar ... No such file or directory** | Install failed for the scoped npm package | Prefer installing via n8n’s Community Nodes UI (search “SearchApi”). If installing manually, use the full package name `@searchapi/n8n-nodes-searchapi` and retry after clearing n8n community-node cache. |
+| **Node not available as AI tool** | Community tool usage disabled | On self-hosted n8n, ensure community nodes can be used as tools (see n8n docs for community package tool usage). Re-install/reload the node after enabling. |
 
 ## Version history
 
@@ -71,15 +109,15 @@ You can see the version history [here](https://github.com/SearchApi/n8n-nodes-se
 1. Run `npm install` to install the dependencies
 2. Run `npm run dev` to start n8n with the node in development mode
 3. Open http://localhost:5678 to access n8n with the node loaded
-4. Make changes to the source files — the node rebuilds automatically on file changes
+4. Make changes to the source files - the node rebuilds automatically on file changes
 
 Other useful commands:
 
-- `npm run build` — compile TypeScript for production
-- `npm run lint` — run ESLint code quality checks
-- `npm run lint:fix` — auto-fix linting issues
-- `npm run release` — bump version, update changelog, and publish to npm
+- `npm run build` - compile TypeScript for production
+- `npm run lint` - run ESLint code quality checks
+- `npm run lint:fix` - auto-fix linting issues
+- `npm run release` - bump version, update changelog, and publish to npm
 
-You will be able to see the the node in the local n8n http://localhost:5678.
+You will be able to see the node in the local n8n http://localhost:5678.
 
 Obs: You might need to run `rm -rf ~/.n8n-node-cli`, to clear the cache of old n8n instances you might have installed, it might make the cli to timeout.

--- a/examples/ai-agent-google-search.workflow.json
+++ b/examples/ai-agent-google-search.workflow.json
@@ -1,0 +1,89 @@
+{
+  "name": "SearchApi AI Agent - Google Search",
+  "nodes": [
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "chat-trigger",
+      "name": "When chat message received",
+      "type": "@n8n/n8n-nodes-langchain.chatTrigger",
+      "typeVersion": 1.1,
+      "position": [0, 0],
+      "webhookId": "searchapi-ai-agent-demo"
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "={{ $json.chatInput }}",
+        "options": {
+          "systemMessage": "You are a research assistant with access to live web search through SearchApi. When the user asks for current information, call the SearchApi tool, then summarize the top results with titles and links."
+        }
+      },
+      "id": "ai-agent",
+      "name": "AI Agent",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 1.7,
+      "position": [280, 0]
+    },
+    {
+      "parameters": {
+        "resource": "google",
+        "operation": "search",
+        "q": "={{ /*n8n-auto-generated-fromAI-override*/ $fromAI('q', 'Search query for Google organic results', 'string') }}"
+      },
+      "id": "searchapi-tool",
+      "name": "SearchApi",
+      "type": "n8n-nodes-searchapi.searchApi",
+      "typeVersion": 1,
+      "position": [280, 240],
+      "credentials": {
+        "searchApi": {
+          "id": "REPLACE_WITH_SEARCHAPI_CREDENTIAL_ID",
+          "name": "SearchApi account"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "When chat message received": {
+      "main": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "SearchApi": {
+      "ai_tool": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "ai_tool",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "meta": {
+    "templateCredsSetupCompleted": false,
+    "instanceId": "searchapi-ai-agent-google-search-example"
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "SearchApi"
+    },
+    {
+      "name": "AI Agent"
+    }
+  ]
+}

--- a/nodes/SearchApi/SearchApi.node.ts
+++ b/nodes/SearchApi/SearchApi.node.ts
@@ -12,7 +12,16 @@ const engines: Engine[] = [google, google_images, google_maps, google_shopping];
 async function stripEmptyQueryParams(this: IExecuteSingleFunctions, requestOptions: IHttpRequestOptions): Promise<IHttpRequestOptions> {
 	if (requestOptions.qs) {
 		for (const key of Object.keys(requestOptions.qs)) {
-			if (requestOptions.qs[key] === '' || requestOptions.qs[key] === undefined) {
+			const value = requestOptions.qs[key];
+			// AI Agents and expressions can resolve optional fields to null or "undefined",
+			// which SearchApi rejects as invalid values instead of ignoring them.
+			if (
+				value === '' ||
+				value === undefined ||
+				value === null ||
+				value === 'undefined' ||
+				value === 'null'
+			) {
 				delete requestOptions.qs[key];
 			}
 		}
@@ -29,7 +38,7 @@ export class SearchApi implements INodeType {
 		version: 1,
 		description:
 			'Access real-time search results from Google, Google Images, Google Maps, Google Shopping and more. Use this when you need current, up-to-date information, product searches, location data, or visual content that may not be available in your training data.',
-		subtitle: '={{ $parameter["engine"] }}',
+		subtitle: '={{ $parameter["resource"] }}',
 		defaults: { name: 'SearchApi' },
 		inputs: ['main'],
 		outputs: ['main'],
@@ -43,7 +52,7 @@ export class SearchApi implements INodeType {
 		},
 		hints: [
 			{
-				message: "Hit SearchAPI's free 100-request quota? Check the Pricing page 📈'",
+				message: "Hit SearchAPI's free 100-request quota? Check the Pricing page 📈",
 				type: 'info',
 				whenToDisplay: 'beforeExecution',
 				location: 'inputPane',


### PR DESCRIPTION
## Summary
- Strip null/"undefined"/"null" values from query params (common when n8n AI Agents fill optional fields)
- Fix subtitle binding from `engine` to `resource`
- Fix broken pricing hint string
- Document AI Agent usage + add example workflow

## Test plan
- [ ] Build/lint pass (`npm run build`, `npm run lint`)
- [ ] Optional fields left empty by an AI Agent no longer send invalid query params
- [ ] Node subtitle shows the selected resource (e.g. google)